### PR TITLE
Implement Chromium fetch helper and CLI command

### DIFF
--- a/artfinder_scraper/README.md
+++ b/artfinder_scraper/README.md
@@ -1,3 +1,17 @@
 # artfinder_scraper Package
 
 This package will contain the scraping logic, tests, and storage helpers for the Artfinder project. The `scraping` subpackage will be populated with indexers, extractors, downloaders, spreadsheet utilities, normalization helpers, typed models, browser helpers, and a runner to orchestrate flows. The `tests` package will house unit and integration coverage for those components, while `data/` and `out/` will persist input caches and generated artifacts.
+
+## Browser helper
+
+`artfinder_scraper.scraping.browsers` exposes `fetch_page_html(url: str)` which drives a headless Chromium instance with the required user agent (`LB-Scraper/1.0`) and a jittered 300–800 ms delay before each navigation. The helper waits for the main content element to render before returning the HTML, making it a convenient building block for the extractor and higher-level orchestration code.
+
+## Command-line interface
+
+The root `scrape_artfinder.py` script hosts a Typer application. The first available subcommand mirrors the specification’s single-item workflow:
+
+```bash
+python scrape_artfinder.py fetch-item https://www.artfinder.com/product/a-windswept-walk/
+```
+
+Pass `--out path/to/file.html` to store the rendered HTML instead of printing it to the terminal.

--- a/artfinder_scraper/scraping/browsers.py
+++ b/artfinder_scraper/scraping/browsers.py
@@ -1,1 +1,101 @@
-"""Provide browser automation utilities for navigating Artfinder pages."""
+"""Provide browser automation utilities for navigating Artfinder pages.
+
+This module centralizes Playwright configuration so that the rest of the
+codebase can rely on a single, polite Chromium driver.  The helper functions
+defined here are intentionally lightweight so they can be mocked during unit
+tests while still exercising the high-level fetching flow.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import random
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+from typing import AsyncIterator, Tuple
+
+from playwright.async_api import Page, TimeoutError as PlaywrightTimeoutError, async_playwright
+
+USER_AGENT: str = "LB-Scraper/1.0"
+POLITENESS_DELAY_SECONDS: Tuple[float, float] = (0.3, 0.8)
+MAIN_CONTENT_SELECTOR: str = "main"
+
+
+@dataclass
+class PolitePage:
+    """Wrap a Playwright page with the project politeness policy applied."""
+
+    page: Page
+    delay_range: Tuple[float, float] = POLITENESS_DELAY_SECONDS
+
+    async def goto_and_wait(
+        self,
+        url: str,
+        *,
+        wait_for_selector: str | None = MAIN_CONTENT_SELECTOR,
+        wait_timeout_ms: int = 10_000,
+        wait_until: str = "networkidle",
+    ) -> None:
+        """Navigate to ``url`` while respecting configured politeness rules."""
+
+        await asyncio.sleep(random.uniform(*self.delay_range))
+        await self.page.goto(url, wait_until=wait_until)
+        if wait_for_selector is not None:
+            try:
+                await self.page.wait_for_selector(wait_for_selector, timeout=wait_timeout_ms)
+            except PlaywrightTimeoutError:
+                await self.page.wait_for_load_state("domcontentloaded")
+
+    async def content(self) -> str:
+        """Return the current page HTML."""
+
+        return await self.page.content()
+
+    async def close(self) -> None:
+        """Close the underlying Playwright page."""
+
+        await self.page.close()
+
+    def __getattr__(self, attribute_name: str):
+        return getattr(self.page, attribute_name)
+
+
+@asynccontextmanager
+async def chromium_page(delay_range: Tuple[float, float] = POLITENESS_DELAY_SECONDS) -> AsyncIterator[PolitePage]:
+    """Launch a Chromium page configured with the project defaults."""
+
+    async with async_playwright() as playwright_driver:
+        browser = await playwright_driver.chromium.launch(headless=True)
+        context = await browser.new_context(user_agent=USER_AGENT)
+        page = await context.new_page()
+        wrapped_page = PolitePage(page=page, delay_range=delay_range)
+        try:
+            yield wrapped_page
+        finally:
+            await wrapped_page.close()
+            await context.close()
+            await browser.close()
+
+
+async def _fetch_page_html_async(url: str, *, main_selector: str = MAIN_CONTENT_SELECTOR) -> str:
+    """Return the rendered HTML for ``url`` once the main content is visible."""
+
+    async with chromium_page() as page:
+        await page.goto_and_wait(url, wait_for_selector=main_selector)
+        return await page.content()
+
+
+def fetch_page_html(url: str, *, main_selector: str = MAIN_CONTENT_SELECTOR) -> str:
+    """Synchronously fetch ``url`` and return its rendered HTML."""
+
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        loop = None
+
+    if loop and loop.is_running():
+        raise RuntimeError(
+            "fetch_page_html cannot be called while an event loop is running. "
+            "Use the `_fetch_page_html_async` coroutine instead."
+        )
+    return asyncio.run(_fetch_page_html_async(url, main_selector=main_selector))

--- a/artfinder_scraper/tests/test_browsers.py
+++ b/artfinder_scraper/tests/test_browsers.py
@@ -1,0 +1,141 @@
+"""Smoke tests for the Playwright browser helpers."""
+from __future__ import annotations
+
+from types import ModuleType
+from typing import Any, Dict, List
+
+import sys
+import pytest
+
+# Provide a lightweight stub for the Playwright imports used by the browser module.
+
+
+class _StubTimeoutError(Exception):
+    """Local stand-in for Playwright's TimeoutError during tests."""
+
+
+async def _placeholder_async_playwright():  # pragma: no cover - patched in tests
+    raise RuntimeError("async_playwright should be patched within tests")
+
+
+fake_playwright_module = ModuleType("playwright")
+fake_async_api_module = ModuleType("playwright.async_api")
+fake_async_api_module.Page = object
+fake_async_api_module.TimeoutError = _StubTimeoutError
+fake_async_api_module.async_playwright = _placeholder_async_playwright
+fake_playwright_module.async_api = fake_async_api_module
+sys.modules.setdefault("playwright", fake_playwright_module)
+sys.modules.setdefault("playwright.async_api", fake_async_api_module)
+
+from artfinder_scraper.scraping import browsers
+
+
+class DummyPage:
+    def __init__(self) -> None:
+        self.goto_calls: List[Dict[str, Any]] = []
+        self.selector_waits: List[Dict[str, Any]] = []
+        self.load_state_waits: List[str] = []
+        self.closed: bool = False
+
+    async def goto(self, url: str, wait_until: str = "load") -> None:
+        self.goto_calls.append({"url": url, "wait_until": wait_until})
+
+    async def wait_for_selector(self, selector: str, timeout: int = 0) -> None:
+        self.selector_waits.append({"selector": selector, "timeout": timeout})
+
+    async def wait_for_load_state(self, state: str) -> None:
+        self.load_state_waits.append(state)
+
+    async def content(self) -> str:
+        return "<html><main>ok</main></html>"
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+class DummyContext:
+    def __init__(self, page: DummyPage) -> None:
+        self.page = page
+        self.closed: bool = False
+
+    async def new_page(self) -> DummyPage:
+        return self.page
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+class DummyBrowser:
+    def __init__(self, context: DummyContext) -> None:
+        self.context = context
+        self.closed: bool = False
+        self.user_agent: str | None = None
+
+    async def new_context(self, user_agent: str) -> DummyContext:
+        self.user_agent = user_agent
+        return self.context
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+class DummyChromiumLauncher:
+    def __init__(self, browser: DummyBrowser) -> None:
+        self.browser = browser
+        self.launch_calls: List[Dict[str, Any]] = []
+
+    async def launch(self, headless: bool = True) -> DummyBrowser:
+        self.launch_calls.append({"headless": headless})
+        return self.browser
+
+
+class DummyPlaywright:
+    def __init__(self, launcher: DummyChromiumLauncher) -> None:
+        self.chromium = launcher
+
+
+class DummyAsyncPlaywright:
+    def __init__(self, playwright: DummyPlaywright) -> None:
+        self.playwright = playwright
+        self.exited: bool = False
+
+    async def __aenter__(self) -> DummyPlaywright:
+        return self.playwright
+
+    async def __aexit__(self, exc_type, exc, traceback) -> None:
+        self.exited = True
+
+
+def test_fetch_page_html_smoke(monkeypatch: pytest.MonkeyPatch) -> None:
+    dummy_page = DummyPage()
+    dummy_context = DummyContext(dummy_page)
+    dummy_browser = DummyBrowser(dummy_context)
+    dummy_launcher = DummyChromiumLauncher(dummy_browser)
+    dummy_playwright = DummyPlaywright(dummy_launcher)
+    dummy_async_playwright = DummyAsyncPlaywright(dummy_playwright)
+
+    monkeypatch.setattr(browsers, "async_playwright", lambda: dummy_async_playwright)
+
+    sleep_calls: List[float] = []
+
+    async def fake_sleep(duration: float) -> None:
+        sleep_calls.append(duration)
+
+    monkeypatch.setattr(browsers.asyncio, "sleep", fake_sleep)
+    monkeypatch.setattr(browsers.random, "uniform", lambda start, end: 0.5)
+
+    html = browsers.fetch_page_html("https://example.com/item")
+
+    assert html == "<html><main>ok</main></html>"
+    assert dummy_page.goto_calls == [
+        {"url": "https://example.com/item", "wait_until": "networkidle"}
+    ]
+    assert dummy_page.selector_waits == [
+        {"selector": browsers.MAIN_CONTENT_SELECTOR, "timeout": 10_000}
+    ]
+    assert sleep_calls == [0.5]
+    assert dummy_browser.user_agent == browsers.USER_AGENT
+    assert dummy_page.closed is True
+    assert dummy_context.closed is True
+    assert dummy_browser.closed is True
+    assert dummy_async_playwright.exited is True

--- a/scrape_artfinder.py
+++ b/scrape_artfinder.py
@@ -1,9 +1,37 @@
-"""TODO: Implement command-line entry point for the Artfinder scraper."""
+"""Command-line entry point for the Artfinder scraper."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+import typer
+
+from artfinder_scraper.scraping.browsers import fetch_page_html
+
+app = typer.Typer(help="Utility commands for interacting with the Artfinder scraper.")
+
+
+@app.command("fetch-item")
+def fetch_item(
+    url: str,
+    output: Optional[Path] = typer.Option(None, "--out", "-o", help="File to write the rendered HTML to."),
+) -> None:
+    """Fetch a single item URL and emit the rendered HTML."""
+
+    html_content = fetch_page_html(url)
+    if output is not None:
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_text(html_content, encoding="utf-8")
+        typer.echo(f"Saved HTML to {output}")
+    else:
+        typer.echo(html_content)
 
 
 def main() -> None:
-    """Placeholder main for future scraping orchestration."""
-    raise NotImplementedError("Scraper entry point not yet implemented.")
+    """Run the Typer CLI application."""
+
+    app()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add a Playwright-backed Chromium context manager that enforces the project user-agent and polite delays
- expose a synchronous `fetch_page_html` helper and wire a Typer `fetch-item` CLI command
- document the new workflow in the package README and cover it with a mocked smoke test

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68de9c27a1e88322ba8bcbba8663a0d6