### PR TITLE
Add GitHub Actions workflow to run tests on pull requests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,30 @@
+name: Run tests
+
+on:
+  pull_request:
+    branches:
+      - "*"
+  push:
+    branches:
+      - main
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pytest
+
+      - name: Run test suite
+        run: pytest

--- a/README.md
+++ b/README.md
@@ -11,3 +11,8 @@ pytest artfinder_scraper/tests/test_extractor.py
 ```
 
 Add `-k <pattern>` to target a specific scenario (for example, sold items) when iterating on parsing logic.
+
+## Continuous integration
+
+All pull requests trigger the GitHub Actions workflow defined in `.github/workflows/test.yml`. The workflow installs the project's Python
+dependencies along with `pytest` before executing the full test suite to guard against regressions before merges.


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that installs dependencies and runs pytest on pull requests
- document the new automated testing workflow in the project README

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e0e49575f48322b9520e3f8c772590