### PR TITLE
Add artwork image downloader and CLI support

### DIFF
--- a/artfinder_scraper/README.md
+++ b/artfinder_scraper/README.md
@@ -14,4 +14,4 @@ The root `scrape_artfinder.py` script hosts a Typer application. The first avail
 python scrape_artfinder.py fetch-item https://www.artfinder.com/product/a-windswept-walk/
 ```
 
-Pass `--out path/to/file.html` to store the rendered HTML instead of printing it to the terminal.
+Pass `--out path/to/file.html` to store the rendered HTML instead of printing it to the terminal. Use `--download-image` to save the hero image to `out/images/` while reporting the stored path in the console output.

--- a/artfinder_scraper/scraping/downloader.py
+++ b/artfinder_scraper/scraping/downloader.py
@@ -1,1 +1,145 @@
 """Handle downloading and caching of artwork imagery and related assets."""
+
+from __future__ import annotations
+
+import time
+import urllib.error
+import urllib.request
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Callable, Iterable
+
+from .browsers import USER_AGENT
+from .models import Artwork
+
+
+class ImageDownloadError(RuntimeError):
+    """Raised when an artwork image cannot be downloaded successfully."""
+
+
+def _resolve_default_output_directory() -> Path:
+    """Return the canonical directory for cached artwork images."""
+
+    package_root = Path(__file__).resolve().parents[1]
+    return package_root / "out" / "images"
+
+
+@dataclass(slots=True)
+class ArtworkImageDownloader:
+    """Download artwork imagery while enforcing type and size checks."""
+
+    max_retries: int = 3
+    backoff_factor: float = 0.5
+    allowed_content_types: Iterable[str] = (
+        "image/jpeg",
+        "image/png",
+        "image/webp",
+        "image/gif",
+    )
+    max_file_size_bytes: int | None = 15 * 1024 * 1024
+    output_directory: Path = field(default_factory=_resolve_default_output_directory)
+    opener: Callable[[urllib.request.Request], object] = urllib.request.urlopen
+    sleep_function: Callable[[float], None] = time.sleep
+
+    def __post_init__(self) -> None:
+        normalized_types = tuple(
+            content_type.lower() for content_type in self.allowed_content_types
+        )
+        object.__setattr__(self, "allowed_content_types", normalized_types)
+        object.__setattr__(self, "output_directory", Path(self.output_directory))
+
+    def download_artwork_image(self, artwork: Artwork) -> Artwork:
+        """Download ``artwork``'s primary image and persist it locally."""
+
+        if artwork.image_url is None:
+            return artwork
+
+        if self.max_retries < 1:
+            raise ValueError("max_retries must be at least 1")
+
+        image_url = str(artwork.image_url)
+        last_error: Exception | None = None
+
+        for attempt in range(1, self.max_retries + 1):
+            try:
+                request = urllib.request.Request(image_url, headers={"User-Agent": USER_AGENT})
+                with self.opener(request) as response:  # type: ignore[arg-type]
+                    content_type = self._extract_content_type(response)
+                    self._validate_content_type(content_type)
+
+                    data = response.read()
+                    if not data:
+                        raise ImageDownloadError("Downloaded image is empty")
+
+                    if (
+                        self.max_file_size_bytes is not None
+                        and len(data) > self.max_file_size_bytes
+                    ):
+                        raise ImageDownloadError(
+                            "Downloaded image exceeds the configured maximum size"
+                        )
+
+                    target_path = self._resolve_target_path(artwork, content_type)
+                    target_path.parent.mkdir(parents=True, exist_ok=True)
+                    target_path.write_bytes(data)
+
+                    update_payload = {"image_path": str(target_path)}
+                    if hasattr(artwork, "model_copy"):
+                        return artwork.model_copy(update=update_payload)
+                    return artwork.copy(update=update_payload)  # type: ignore[attr-defined]
+
+            except ImageDownloadError:
+                raise
+            except (urllib.error.URLError, OSError) as error:
+                last_error = error
+                if attempt >= self.max_retries:
+                    message = (
+                        f"Failed to download artwork image after {attempt} attempts: {error}"
+                    )
+                    raise ImageDownloadError(message) from error
+                sleep_duration = self.backoff_factor * (2 ** (attempt - 1))
+                self.sleep_function(sleep_duration)
+
+        if last_error is not None:  # pragma: no cover - defensive guard
+            raise ImageDownloadError("Failed to download artwork image") from last_error
+        return artwork  # pragma: no cover - unreachable without errors
+
+    def _extract_content_type(self, response: object) -> str:
+        """Return the response content type in lowercase form."""
+
+        header_value: str | None = None
+        if hasattr(response, "headers") and response.headers is not None:
+            header_value = response.headers.get("Content-Type")
+        if header_value is None and hasattr(response, "getheader"):
+            header_value = response.getheader("Content-Type")  # type: ignore[attr-defined]
+        if header_value is None and hasattr(response, "info"):
+            info = response.info()  # type: ignore[attr-defined]
+            if info is not None:
+                header_value = info.get("Content-Type")
+        if header_value is None:
+            raise ImageDownloadError("Response did not include a Content-Type header")
+        return header_value.split(";")[0].strip().lower()
+
+    def _validate_content_type(self, content_type: str) -> None:
+        """Ensure the response content type is in the allowed list."""
+
+        if content_type not in self.allowed_content_types:
+            raise ImageDownloadError(
+                f"Content type '{content_type}' is not allowed for artwork imagery"
+            )
+
+    def _resolve_target_path(self, artwork: Artwork, content_type: str) -> Path:
+        """Determine the output filename for the downloaded image."""
+
+        extension_map = {
+            "image/jpeg": ".jpg",
+            "image/png": ".png",
+            "image/webp": ".webp",
+            "image/gif": ".gif",
+        }
+        extension = extension_map.get(content_type, ".bin")
+        slug = artwork.slug or "artwork"
+        return self.output_directory / f"{slug}{extension}"
+
+
+__all__ = ["ArtworkImageDownloader", "ImageDownloadError"]

--- a/artfinder_scraper/scraping/readme.md
+++ b/artfinder_scraper/scraping/readme.md
@@ -14,9 +14,12 @@ command-line workflow to download and process Artfinder artwork pages.
 * `models.py` defines the `Artwork` schema used across the scraping
   workflow, handling GBP price normalization, slug derivation from
   `/product/<slug>/` URLs, and timestamping when a record was scraped.
-* `downloader.py`, `indexer.py`, `normalize.py`, `spreadsheet.py`, and
-  `runner.py` are placeholders for the upcoming pagination, normalization, and
-  orchestration layers described in the project spec.
+* `downloader.py` provides `ArtworkImageDownloader`, a retrying HTTP client
+  that stores validated image responses under `out/images/` while populating
+  each `Artwork.image_path` for downstream consumers. `indexer.py`,
+  `normalize.py`, `spreadsheet.py`, and `runner.py` remain placeholders for the
+  upcoming pagination, normalization, and orchestration layers described in the
+  project spec.
 
 ## Fetching a single artwork
 

--- a/artfinder_scraper/tests/test_downloader.py
+++ b/artfinder_scraper/tests/test_downloader.py
@@ -1,0 +1,128 @@
+"""Unit tests for the artwork image downloader."""
+
+from __future__ import annotations
+
+import urllib.error
+from dataclasses import dataclass
+from typing import Dict
+
+import pytest
+
+from artfinder_scraper.scraping.downloader import (
+    ArtworkImageDownloader,
+    ImageDownloadError,
+)
+from artfinder_scraper.scraping.models import Artwork
+
+
+@dataclass
+class DummyResponse:
+    """Minimal HTTP response stub for downloader tests."""
+
+    data: bytes
+    headers: Dict[str, str]
+
+    def read(self) -> bytes:
+        return self.data
+
+    def info(self) -> Dict[str, str]:  # pragma: no cover - compatibility hook
+        return self.headers
+
+    def __enter__(self) -> "DummyResponse":
+        return self
+
+    def __exit__(self, exc_type, exc, traceback) -> None:  # pragma: no cover - context protocol
+        return None
+
+
+def _make_artwork(image_url: str | None = "https://cdn.example.com/image.jpg") -> Artwork:
+    return Artwork(
+        title="Example",
+        description=None,
+        price_gbp=None,
+        size=None,
+        sold=False,
+        image_url=image_url,
+        source_url="https://www.artfinder.com/product/example-artwork/",
+    )
+
+
+def test_download_artwork_image_retries_then_succeeds(tmp_path) -> None:
+    """The downloader should retry failed requests with backoff delays."""
+
+    request_urls: list[str] = []
+    sleep_calls: list[float] = []
+
+    def fake_opener(request):
+        request_urls.append(request.full_url)
+        if len(request_urls) == 1:
+            raise urllib.error.URLError("temporary network issue")
+        return DummyResponse(data=b"binary-image", headers={"Content-Type": "image/jpeg"})
+
+    def fake_sleep(duration: float) -> None:
+        sleep_calls.append(duration)
+
+    downloader = ArtworkImageDownloader(
+        max_retries=3,
+        backoff_factor=0.2,
+        output_directory=tmp_path,
+        opener=fake_opener,
+        sleep_function=fake_sleep,
+    )
+
+    artwork = _make_artwork()
+    updated_artwork = downloader.download_artwork_image(artwork)
+
+    assert request_urls == ["https://cdn.example.com/image.jpg", "https://cdn.example.com/image.jpg"]
+    assert sleep_calls == [0.2]
+    expected_path = tmp_path / "example-artwork.jpg"
+    assert updated_artwork.image_path == str(expected_path)
+    assert expected_path.read_bytes() == b"binary-image"
+
+
+def test_download_artwork_image_rejects_invalid_content_type(tmp_path) -> None:
+    """Non-image responses should raise a validation error."""
+
+    def fake_opener(request):
+        return DummyResponse(data=b"not-image", headers={"Content-Type": "text/html"})
+
+    downloader = ArtworkImageDownloader(
+        output_directory=tmp_path,
+        opener=fake_opener,
+    )
+
+    with pytest.raises(ImageDownloadError) as error_info:
+        downloader.download_artwork_image(_make_artwork())
+
+    assert "Content type" in str(error_info.value)
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_download_artwork_image_returns_original_when_missing_url(tmp_path) -> None:
+    """Artworks without an image URL should be skipped without errors."""
+
+    downloader = ArtworkImageDownloader(output_directory=tmp_path)
+
+    artwork = _make_artwork(image_url=None)
+    result = downloader.download_artwork_image(artwork)
+
+    assert result is artwork
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_download_artwork_image_rejects_empty_payload(tmp_path) -> None:
+    """Zero-byte downloads must be treated as failures."""
+
+    def fake_opener(request):
+        return DummyResponse(data=b"", headers={"Content-Type": "image/png"})
+
+    downloader = ArtworkImageDownloader(
+        output_directory=tmp_path,
+        opener=fake_opener,
+    )
+
+    with pytest.raises(ImageDownloadError) as error_info:
+        downloader.download_artwork_image(_make_artwork())
+
+    assert "empty" in str(error_info.value)
+    assert list(tmp_path.iterdir()) == []

--- a/scrape_artfinder.py
+++ b/scrape_artfinder.py
@@ -8,6 +8,10 @@ from typing import Optional
 import typer
 
 from artfinder_scraper.scraping.browsers import fetch_page_html
+from artfinder_scraper.scraping.downloader import (
+    ArtworkImageDownloader,
+    ImageDownloadError,
+)
 from artfinder_scraper.scraping.extractor import extract_artwork_fields
 
 
@@ -34,6 +38,12 @@ def fetch_item(
         "-o",
         help="File to write the rendered HTML to.",
     ),
+    download_image: bool = typer.Option(
+        False,
+        "--download-image",
+        help="Download the primary artwork image after extraction.",
+        is_flag=True,
+    ),
 ) -> None:
     """Fetch a single item URL and emit the rendered HTML."""
 
@@ -44,6 +54,18 @@ def fetch_item(
         typer.echo(f"Saved HTML to {output}")
 
     artwork = extract_artwork_fields(html_content, url)
+
+    if download_image:
+        downloader = ArtworkImageDownloader()
+        try:
+            artwork = downloader.download_artwork_image(artwork)
+            if artwork.image_path:
+                typer.echo(f"Saved image to {artwork.image_path}")
+            else:
+                typer.echo("Artwork did not include an image URL; nothing downloaded.")
+        except ImageDownloadError as error:
+            typer.echo(f"Failed to download image: {error}", err=True)
+
     typer.echo("Parsed fields:")
     if hasattr(artwork, "model_dump"):
         serialized = artwork.model_dump()


### PR DESCRIPTION
## Summary
- implement an ArtworkImageDownloader that validates content type, size, and retries downloads before caching images
- add unit tests that exercise retry, validation, and file writing behaviour using mocked HTTP responses
- extend the fetch-item CLI with an optional image download flag and update documentation to describe the new workflow

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e0e4795a08832292e86cba50e2a483