### PR TITLE
Ensure description extraction stops before materials header

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This project will crawl every artwork listed on Lizzie Butler's Artfinder shop, 
 
 ## Running extractor tests
 
-The extractor uses saved HTML fixtures to verify that titles, prices, size text, sold state, and images are detected correctly. Execute the focused test module with:
+The extractor uses saved HTML fixtures to verify that titles, prices, size text, sold state, images, and materials used copy are detected correctly. Execute the focused test module with:
 
 ```bash
 pytest artfinder_scraper/tests/test_extractor.py

--- a/artfinder_scraper/scraping/extractor.py
+++ b/artfinder_scraper/scraping/extractor.py
@@ -79,19 +79,20 @@ def _extract_description(soup: BeautifulSoup) -> Optional[str]:
 
 
 def _extract_materials_used(soup: BeautifulSoup) -> Optional[str]:
-    heading = soup.find("h5", class_="header-art")
-    if not heading:
-        return None
-
-    for sibling in heading.next_siblings:
-        if isinstance(sibling, NavigableString):
+    for heading in soup.find_all("h5", class_="header-art"):
+        heading_text = heading.get_text(" ", strip=True)
+        if "material" not in heading_text.lower():
             continue
-        if isinstance(sibling, Tag):
-            if sibling.name == "p":
-                text = sibling.get_text(" ", strip=True)
-                cleaned = _normalize_whitespace(text)
-                return cleaned or None
-            break
+
+        for sibling in heading.next_siblings:
+            if isinstance(sibling, NavigableString):
+                continue
+            if isinstance(sibling, Tag):
+                if sibling.name == "p":
+                    text = sibling.get_text(" ", strip=True)
+                    cleaned = _normalize_whitespace(text)
+                    return cleaned or None
+                break
     return None
 
 

--- a/artfinder_scraper/scraping/extractor.py
+++ b/artfinder_scraper/scraping/extractor.py
@@ -60,6 +60,11 @@ def _extract_description(soup: BeautifulSoup) -> Optional[str]:
             if isinstance(sibling, NavigableString):
                 continue
             if isinstance(sibling, Tag):
+                sibling_classes = sibling.get("class") or []
+                if sibling.name == "h5" and "header-art" in sibling_classes:
+                    break
+                if sibling.find("h5", class_="header-art"):
+                    break
                 if sibling.name in {"h1", "h2", "h3"}:
                     break
                 if sibling.find(string=re.compile("Specifications", re.IGNORECASE)):
@@ -70,6 +75,23 @@ def _extract_description(soup: BeautifulSoup) -> Optional[str]:
         cleaned_paragraphs = [para for para in (_normalize_whitespace(p) for p in paragraphs) if para]
         if cleaned_paragraphs:
             return "\n\n".join(cleaned_paragraphs)
+    return None
+
+
+def _extract_materials_used(soup: BeautifulSoup) -> Optional[str]:
+    heading = soup.find("h5", class_="header-art")
+    if not heading:
+        return None
+
+    for sibling in heading.next_siblings:
+        if isinstance(sibling, NavigableString):
+            continue
+        if isinstance(sibling, Tag):
+            if sibling.name == "p":
+                text = sibling.get_text(" ", strip=True)
+                cleaned = _normalize_whitespace(text)
+                return cleaned or None
+            break
     return None
 
 
@@ -170,6 +192,7 @@ def extract_artwork_fields(html: str, source_url: str) -> Artwork:
     size = _extract_size_text(soup)
     sold = _extract_sold_state(soup)
     image_url = _extract_image_url(soup, title)
+    materials_used = _extract_materials_used(soup)
 
     artwork = Artwork(
         title=title,
@@ -178,6 +201,7 @@ def extract_artwork_fields(html: str, source_url: str) -> Artwork:
         size=size,
         sold=sold,
         image_url=image_url,
+        materials_used=materials_used,
         source_url=source_url,
     )
     return artwork

--- a/artfinder_scraper/scraping/models.py
+++ b/artfinder_scraper/scraping/models.py
@@ -44,6 +44,10 @@ class Artwork(BaseModel):
         default=None,
         description="Local filesystem path of the downloaded image, if available.",
     )
+    materials_used: str | None = Field(
+        default=None,
+        description="Materials listed for the artwork, captured from the specification panel.",
+    )
     source_url: HttpUrl = Field(..., description="Canonical URL of the artwork detail page.")
     scraped_at: datetime = Field(
         default_factory=lambda: datetime.now(timezone.utc),
@@ -63,7 +67,7 @@ class Artwork(BaseModel):
             raise ValueError("title must not be empty")
         return cleaned
 
-    @validator("description", "size", "image_path", pre=True)
+    @validator("description", "size", "image_path", "materials_used", pre=True)
     def _strip_optional_fields(cls, value: Any) -> Any:
         """Collapse blank optional strings to ``None``."""
 

--- a/artfinder_scraper/scraping/readme.md
+++ b/artfinder_scraper/scraping/readme.md
@@ -9,10 +9,11 @@ command-line workflow to download and process Artfinder artwork pages.
   values that higher-level flows can normalize later on, including
   consolidating size metadata from `product-attributes` spans while
   stripping inert comment fragments from the collected text. It also
-  captures the "materials used" copy surfaced beneath the `header-art`
-  heading, flattening hyperlinks to plain text. The extractor now
-  materializes an `Artwork` pydantic model so that downstream components
-  receive validated, typed data.
+  captures the "materials used" copy surfaced beneath the dedicated
+  `header-art` heading even when other `header-art` elements precede it,
+  flattening hyperlinks to plain text. The extractor now materializes an
+  `Artwork` pydantic model so that downstream components receive
+  validated, typed data.
 * `models.py` defines the `Artwork` schema used across the scraping
   workflow, handling GBP price normalization, slug derivation from
   `/product/<slug>/` URLs, and timestamping when a record was scraped.

--- a/artfinder_scraper/scraping/readme.md
+++ b/artfinder_scraper/scraping/readme.md
@@ -8,9 +8,11 @@ command-line workflow to download and process Artfinder artwork pages.
 * `extractor.py` parses the rendered HTML into a dictionary of raw field
   values that higher-level flows can normalize later on, including
   consolidating size metadata from `product-attributes` spans while
-  stripping inert comment fragments from the collected text. The
-  extractor now materializes an `Artwork` pydantic model so that
-  downstream components receive validated, typed data.
+  stripping inert comment fragments from the collected text. It also
+  captures the "materials used" copy surfaced beneath the `header-art`
+  heading, flattening hyperlinks to plain text. The extractor now
+  materializes an `Artwork` pydantic model so that downstream components
+  receive validated, typed data.
 * `models.py` defines the `Artwork` schema used across the scraping
   workflow, handling GBP price normalization, slug derivation from
   `/product/<slug>/` URLs, and timestamping when a record was scraped.

--- a/artfinder_scraper/tests/fixtures/soft_light_sold.html
+++ b/artfinder_scraper/tests/fixtures/soft_light_sold.html
@@ -14,7 +14,7 @@
         <img src="https://cdn.example.com/images/soft-light-main.jpg" alt="Soft Light painting by Lizzie Butler" />
       </section>
       <article>
-        <h2>Original artwork description</h2>
+        <h5 class="header-art">Original artwork description</h5>
         <p>Delicate hues describe the gentle evening light across the bay.</p>
       </article>
       <section class="specs">

--- a/artfinder_scraper/tests/fixtures/soft_light_sold.html
+++ b/artfinder_scraper/tests/fixtures/soft_light_sold.html
@@ -27,6 +27,10 @@
           <span>: Oil on canvas</span>
         </div>
       </section>
+      <section class="artwork-details">
+        <h5 class="header-art">Materials used</h5>
+        <p>Oil on canvas with silver leaf highlights</p>
+      </section>
     </main>
   </body>
 </html>

--- a/artfinder_scraper/tests/fixtures/windswept_walk.html
+++ b/artfinder_scraper/tests/fixtures/windswept_walk.html
@@ -32,6 +32,10 @@
           <span>: Oil on board</span>
         </div>
       </section>
+      <section class="artwork-materials">
+        <h5 class="header-art">Materials used</h5>
+        <p><a href="/medium/oil">Oil</a> on board with <a href="/additions">added texture</a></p>
+      </section>
     </main>
   </body>
 </html>

--- a/artfinder_scraper/tests/fixtures/windswept_walk.html
+++ b/artfinder_scraper/tests/fixtures/windswept_walk.html
@@ -15,7 +15,7 @@
         </div>
       </section>
       <article>
-        <h2>Original artwork description</h2>
+        <h5 class="header-art">Original artwork description</h5>
         <div class="copy">
           <p>This windswept walk captures the energy of the coastline.</p>
           <p>Layers of oil paint bring movement to the clouds and surf.</p>

--- a/artfinder_scraper/tests/test_extractor.py
+++ b/artfinder_scraper/tests/test_extractor.py
@@ -48,6 +48,10 @@ def test_extract_artwork_fields_for_available_item() -> None:
         == "https://cdn.example.com/images/windswept-walk.jpg"
     )
     assert (
+        artwork.materials_used
+        == "Oil on board with added texture"
+    )
+    assert (
         str(artwork.source_url)
         == "https://www.artfinder.com/product/a-windswept-walk/"
     )
@@ -76,9 +80,41 @@ def test_extract_artwork_fields_handles_sold_item_with_missing_depth() -> None:
         == "https://cdn.example.com/images/soft-light-main.jpg"
     )
     assert (
+        artwork.materials_used
+        == "Oil on canvas with silver leaf highlights"
+    )
+    assert (
         str(artwork.source_url)
         == "https://www.artfinder.com/product/soft-light-kew-gardens-an-atmospheric-oil-painting/"
     )
+
+
+def test_description_extraction_stops_before_materials_section() -> None:
+    html = """
+    <html>
+      <body>
+        <main>
+          <section class=\"hero\">
+            <h1>Drift (2024) Oil painting by Lizzie Butler</h1>
+          </section>
+          <article>
+            <h2>Original artwork description</h2>
+            <p>An expansive shoreline bathed in morning light.</p>
+            <h5 class=\"header-art\">Materials used</h5>
+            <p><a href=\"/medium/oil\">Oil</a> and <a href=\"/medium/wax\">wax</a> on panel</p>
+          </article>
+        </main>
+      </body>
+    </html>
+    """
+
+    artwork = extract_artwork_fields(
+        html,
+        "https://www.artfinder.com/product/drift/",
+    )
+
+    assert artwork.description == "An expansive shoreline bathed in morning light."
+    assert artwork.materials_used == "Oil and wax on panel"
 
 
 def test_missing_title_raises_value_error() -> None:

--- a/artfinder_scraper/tests/test_models.py
+++ b/artfinder_scraper/tests/test_models.py
@@ -17,12 +17,14 @@ def test_artwork_model_parses_price_and_slug() -> None:
         size="50 x 70 cm",
         sold=False,
         image_url="https://cdn.example.com/images/evening-glow.jpg",
+        materials_used="Oil on canvas ",
         source_url="https://www.artfinder.com/product/evening-glow/",
     )
 
     assert artwork.price_gbp == Decimal("1234")
     assert artwork.slug == "evening-glow"
     assert artwork.scraped_at.tzinfo is not None
+    assert artwork.materials_used == "Oil on canvas"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- halt description parsing when the header-art materials heading is encountered
- add a regression test ensuring materials copy stays out of the description while still being extracted

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e0e41880488322b48f6937335f6841