### PR TITLE
Add scraper runner orchestration and CLI run command

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,23 @@ https://www.artfinder.com/product/shoreline-2024-oil-painting/
 
 The URLs are deduplicated and normalized by slug so downstream crawlers can feed them directly into the detail-page workflow.
 
+## Run the orchestration pipeline
+
+A smoke-test `run` command wires the orchestrator together so you can validate end-to-end progress without writing custom scripts. It paginates through the configured listing, fetches each detail page, normalizes records, downloads images, and appends JSONL rows under `artfinder_scraper/data/artworks.jsonl` by default.
+
+```bash
+python scrape_artfinder.py run --limit 3 --rate-limit 1.5
+```
+
+Key options:
+
+* `--limit` – cap how many artworks are processed during the run (omit to crawl the entire listing).
+* `--listing-url` – change which artist listing is crawled.
+* `--jsonl-path` – store the JSONL output somewhere other than the default project location.
+* `--rate-limit` – control the minimum delay between detail page fetches.
+
+The command prints a one-line summary when complete and lists any recoverable errors that were skipped along the way so you can iterate on extraction fidelity.
+
 ## Continuous integration
 
 All pull requests trigger the GitHub Actions workflow defined in `.github/workflows/test.yml`. The workflow installs the project's Python

--- a/artfinder_scraper/scraping/normalize.py
+++ b/artfinder_scraper/scraping/normalize.py
@@ -1,1 +1,48 @@
 """Standardize scraped values and enforce consistent schema shapes."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from decimal import Decimal
+from typing import Any, Mapping
+
+from .models import Artwork
+
+
+def _artwork_to_mapping(artwork: Artwork) -> dict[str, Any]:
+    """Return a dictionary representation of ``artwork`` suitable for JSON serialization."""
+
+    if hasattr(artwork, "model_dump"):
+        return artwork.model_dump()
+    return artwork.dict()  # type: ignore[attr-defined]
+
+
+def _convert_json_safe(value: Any) -> Any:
+    """Convert ``value`` into a JSON-serializable representation."""
+
+    if isinstance(value, dict):
+        return {key: _convert_json_safe(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_convert_json_safe(item) for item in value]
+    if isinstance(value, Decimal):
+        return str(value)
+    if isinstance(value, datetime):
+        return value.isoformat()
+    return value
+
+
+def normalize_artwork(artwork: Artwork, extra_fields: Mapping[str, Any] | None = None) -> dict[str, Any]:
+    """Return a JSON-serializable mapping for ``artwork``.
+
+    The returned dictionary merges the standard artwork fields with any
+    ``extra_fields`` provided by upstream processing steps. Optional values are
+    preserved so that downstream archives retain the original record fidelity.
+    """
+
+    payload = _artwork_to_mapping(artwork)
+    if extra_fields:
+        payload.update(extra_fields)
+    return _convert_json_safe(payload)
+
+
+__all__ = ["normalize_artwork"]

--- a/artfinder_scraper/scraping/readme.md
+++ b/artfinder_scraper/scraping/readme.md
@@ -27,7 +27,8 @@ command-line workflow to download and process Artfinder artwork pages.
   into JSON-serializable dictionaries for archival storage.
 * `runner.py` implements `ScraperRunner`, the orchestrator that walks listing
   pagination, fetches detail pages, normalizes the resulting records, downloads
-  imagery, and appends JSONL entries.
+  imagery, and appends JSONL entries. The CLI exposes a `run` command wired to
+  this class so the entire flow can be exercised from the terminal.
 
 ## Fetching a single artwork
 

--- a/artfinder_scraper/scraping/readme.md
+++ b/artfinder_scraper/scraping/readme.md
@@ -20,15 +20,14 @@ command-line workflow to download and process Artfinder artwork pages.
 * `indexer.py` navigates listing pages with a Playwright page handle,
   iterates through pagination, and yields canonical `/product/` links
   while removing duplicates across pages and logging crawl progress.
-* `downloader.py`, `normalize.py`, `spreadsheet.py`, and
-  `runner.py` are placeholders for the upcoming pagination, normalization, and
-  orchestration layers described in the project spec.
 * `downloader.py` provides `ArtworkImageDownloader`, a retrying HTTP client
   that stores validated image responses under `out/images/` while populating
-  each `Artwork.image_path` for downstream consumers. `indexer.py`,
-  `normalize.py`, `spreadsheet.py`, and `runner.py` remain placeholders for the
-  upcoming pagination, normalization, and orchestration layers described in the
-  project spec.
+  each `Artwork.image_path` for downstream consumers.
+* `normalize.py` contains helpers that convert the pydantic `Artwork` model
+  into JSON-serializable dictionaries for archival storage.
+* `runner.py` implements `ScraperRunner`, the orchestrator that walks listing
+  pagination, fetches detail pages, normalizes the resulting records, downloads
+  imagery, and appends JSONL entries.
 
 ## Fetching a single artwork
 

--- a/artfinder_scraper/scraping/runner.py
+++ b/artfinder_scraper/scraping/runner.py
@@ -1,1 +1,198 @@
 """Orchestrate scraping workflow execution and high-level control flow."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import time
+from collections.abc import AsyncIterator, Awaitable, Callable, Iterable, Mapping
+from dataclasses import dataclass
+from datetime import date, datetime
+from decimal import Decimal
+from pathlib import Path
+from typing import Any
+
+from .browsers import _fetch_page_html_async, chromium_page
+from .downloader import ArtworkImageDownloader, ImageDownloadError
+from .extractor import extract_artwork_fields
+from .indexer import iter_listing_product_urls
+from .models import Artwork, ValidationError
+from .normalize import normalize_artwork
+
+DEFAULT_LISTING_URL: str = "https://www.artfinder.com/artist/lizziebutler/sort-newest/"
+
+
+@dataclass(frozen=True)
+class RunnerError:
+    """Represents a recoverable error encountered while processing an item."""
+
+    product_url: str
+    stage: str
+    message: str
+
+
+class ScraperRunner:
+    """Coordinate the high-level scraping pipeline end-to-end."""
+
+    DEFAULT_JSONL_PATH: Path = Path(__file__).resolve().parents[1] / "data" / "artworks.jsonl"
+
+    def __init__(
+        self,
+        listing_url: str = DEFAULT_LISTING_URL,
+        *,
+        fetch_html: Callable[[str], Awaitable[str]] = _fetch_page_html_async,
+        extractor: Callable[[str, str], Artwork] = extract_artwork_fields,
+        normalizer: Callable[[Artwork], Mapping[str, Any]] = normalize_artwork,
+        downloader: ArtworkImageDownloader | None = None,
+        listing_iterator: Callable[
+            [str, Any], AsyncIterator[str]
+        ] = iter_listing_product_urls,
+        page_factory: Callable[[], Any] = chromium_page,
+        jsonl_path: Path | None = None,
+        rate_limit_seconds: float = 0.0,
+        sleep_function: Callable[[float], Awaitable[None]] = asyncio.sleep,
+        time_function: Callable[[], float] = time.monotonic,
+        logger: logging.Logger | None = None,
+    ) -> None:
+        self.listing_url = listing_url
+        self.fetch_html = fetch_html
+        self.extractor = extractor
+        self.normalizer = normalizer
+        self.downloader = downloader or ArtworkImageDownloader()
+        self.listing_iterator = listing_iterator
+        self.page_factory = page_factory
+        self.jsonl_path = Path(jsonl_path) if jsonl_path else self.DEFAULT_JSONL_PATH
+        self.rate_limit_seconds = max(rate_limit_seconds, 0.0)
+        self.sleep_function = sleep_function
+        self.time_function = time_function
+        self.logger = logger or logging.getLogger(__name__)
+        self.errors: list[RunnerError] = []
+
+    async def crawl(self, *, max_items: int | None = None) -> list[Artwork]:
+        """Run the scraping pipeline and return processed artworks."""
+
+        self.errors.clear()
+        processed_artworks: list[Artwork] = []
+        processed_count = 0
+        last_request_timestamp: float | None = None
+
+        self.jsonl_path.parent.mkdir(parents=True, exist_ok=True)
+
+        async with self.page_factory() as page:
+            async for product_url in self._iter_product_urls(page):
+                if max_items is not None and processed_count >= max_items:
+                    break
+
+                self.logger.info("Processing %s", product_url)
+                try:
+                    last_request_timestamp = await self._respect_rate_limit(last_request_timestamp)
+                    html = await self.fetch_html(product_url)
+                    last_request_timestamp = self.time_function()
+                except Exception as error:  # pragma: no cover - network errors handled generically
+                    self._record_error(product_url, "fetch", error)
+                    continue
+
+                try:
+                    artwork = self.extractor(html, product_url)
+                except (ValidationError, ValueError) as error:
+                    self._record_error(product_url, "extract", error)
+                    continue
+
+                try:
+                    artwork = self._download_artwork_image(artwork)
+                except ImageDownloadError as error:
+                    self._record_error(product_url, "download", error)
+                    continue
+
+                try:
+                    normalized_record = self.normalizer(artwork)
+                    json_ready_record = self._prepare_json_record(normalized_record, artwork)
+                except Exception as error:
+                    self._record_error(product_url, "normalize", error)
+                    continue
+
+                try:
+                    self._append_jsonl_record(json_ready_record)
+                except OSError as error:
+                    self._record_error(product_url, "persist", error)
+                    continue
+
+                processed_artworks.append(artwork)
+                processed_count += 1
+                self.logger.info("Processed %s (%s total)", product_url, processed_count)
+
+        return processed_artworks
+
+    def run(self, *, max_items: int | None = None) -> list[Artwork]:
+        """Synchronous convenience wrapper around :meth:`crawl`."""
+
+        return asyncio.run(self.crawl(max_items=max_items))
+
+    async def _iter_product_urls(self, page) -> AsyncIterator[str]:
+        async for product_url in self.listing_iterator(
+            self.listing_url, page, logger=self.logger
+        ):
+            yield product_url
+
+    async def _respect_rate_limit(self, last_timestamp: float | None) -> float | None:
+        if last_timestamp is None:
+            return self.time_function()
+
+        if self.rate_limit_seconds <= 0:
+            return self.time_function()
+
+        current_timestamp = self.time_function()
+        elapsed = current_timestamp - last_timestamp
+        remaining = self.rate_limit_seconds - elapsed
+        if remaining > 0:
+            await self.sleep_function(remaining)
+            current_timestamp = self.time_function()
+        return current_timestamp
+
+    def _download_artwork_image(self, artwork: Artwork) -> Artwork:
+        downloader_callable = getattr(self.downloader, "download_artwork_image", None)
+        if callable(downloader_callable):
+            return downloader_callable(artwork)
+        if callable(self.downloader):  # pragma: no cover - fallback for functional mocks
+            return self.downloader(artwork)  # type: ignore[return-value]
+        raise TypeError("downloader must be callable or expose download_artwork_image")
+
+    def _prepare_json_record(
+        self, normalized_record: Mapping[str, Any], artwork: Artwork
+    ) -> dict[str, Any]:
+        record = dict(normalized_record)
+        if "slug" not in record:
+            record["slug"] = artwork.slug
+        if "source_url" not in record:
+            record["source_url"] = str(artwork.source_url)
+        return self._make_json_safe(record)
+
+    def _make_json_safe(self, value: Any) -> Any:
+        if isinstance(value, Mapping):
+            return {key: self._make_json_safe(item) for key, item in value.items()}
+        if isinstance(value, Iterable) and not isinstance(value, (str, bytes, bytearray)):
+            return [self._make_json_safe(item) for item in value]
+        if isinstance(value, Artwork):
+            return self._make_json_safe(normalize_artwork(value))
+        if isinstance(value, (datetime, date)):
+            return value.isoformat()
+        if isinstance(value, Decimal):
+            return str(value)
+        if isinstance(value, (str, bytes, bytearray, int, float, bool)) or value is None:
+            return value
+        if hasattr(value, "__str__"):
+            return str(value)
+        return value
+
+    def _append_jsonl_record(self, record: Mapping[str, Any]) -> None:
+        with self.jsonl_path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(record, ensure_ascii=False) + "\n")
+
+    def _record_error(self, product_url: str, stage: str, error: Exception) -> None:
+        message = f"{stage} failed for {product_url}: {error}"
+        self.logger.error(message)
+        self.errors.append(RunnerError(product_url=product_url, stage=stage, message=str(error)))
+
+
+__all__ = ["ScraperRunner", "RunnerError", "DEFAULT_LISTING_URL"]

--- a/artfinder_scraper/tests/test_cli.py
+++ b/artfinder_scraper/tests/test_cli.py
@@ -1,0 +1,95 @@
+"""CLI integration coverage for the scrape_artfinder application."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, List, Optional
+
+from typer.testing import CliRunner
+
+import scrape_artfinder
+
+
+class DummyRunner:
+    """Test double that mimics :class:`ScraperRunner` construction and execution."""
+
+    def __init__(
+        self,
+        *,
+        listing_url: str,
+        jsonl_path: Optional[Path],
+        rate_limit_seconds: float,
+        **_: Any,
+    ) -> None:
+        self.listing_url = listing_url
+        self.jsonl_path = jsonl_path or Path("artfinder_scraper/data/artworks.jsonl")
+        self.rate_limit_seconds = rate_limit_seconds
+        self.errors: list[Any] = []
+        self._captured_limits: List[Optional[int]] = []
+
+    def run(self, *, max_items: Optional[int] = None) -> list[object]:
+        self._captured_limits.append(max_items)
+        return [object() for _ in range(max_items or 0)]
+
+
+class DummyErrorRunner(DummyRunner):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self.errors = [
+            type("Err", (), {"stage": "extract", "product_url": "https://example.com/", "message": "failure"})()
+        ]
+
+
+def test_run_command_invokes_runner_with_options(monkeypatch, tmp_path) -> None:
+    invoked: dict[str, Any] = {}
+
+    def factory(**kwargs: Any) -> DummyRunner:
+        runner = DummyRunner(**kwargs)
+        invoked.update(
+            {
+                "listing_url": runner.listing_url,
+                "jsonl_path": runner.jsonl_path,
+                "rate_limit": runner.rate_limit_seconds,
+                "runner": runner,
+            }
+        )
+        return runner
+
+    monkeypatch.setattr(scrape_artfinder, "ScraperRunner", factory)
+
+    jsonl_target = tmp_path / "artworks.jsonl"
+
+    result = CliRunner().invoke(
+        scrape_artfinder.app,
+        [
+            "run",
+            "--limit",
+            "2",
+            "--listing-url",
+            "https://example.com/listing/",
+            "--jsonl-path",
+            str(jsonl_target),
+            "--rate-limit",
+            "0.75",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert "Processed 2 artwork(s);" in result.stdout
+    assert invoked["listing_url"] == "https://example.com/listing/"
+    assert invoked["jsonl_path"] == jsonl_target
+    assert invoked["rate_limit"] == 0.75
+    assert invoked["runner"]._captured_limits == [2]
+
+
+def test_run_command_reports_errors(monkeypatch) -> None:
+    def factory(**kwargs: Any) -> DummyErrorRunner:
+        return DummyErrorRunner(**kwargs)
+
+    monkeypatch.setattr(scrape_artfinder, "ScraperRunner", factory)
+
+    result = CliRunner().invoke(scrape_artfinder.app, ["run", "--limit", "0"])
+
+    assert result.exit_code == 0
+    assert "Encountered the following errors:" in result.stderr
+    assert "[extract]" in result.stderr

--- a/artfinder_scraper/tests/test_runner.py
+++ b/artfinder_scraper/tests/test_runner.py
@@ -1,0 +1,192 @@
+"""Integration coverage for the scraper runner orchestration pipeline."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from contextlib import asynccontextmanager
+from typing import AsyncIterator, List
+
+import pytest
+
+from artfinder_scraper.scraping.models import Artwork
+from artfinder_scraper.scraping.runner import ScraperRunner
+
+
+def _build_artwork(product_url: str, index: int) -> Artwork:
+    """Return a deterministic :class:`Artwork` instance for the given URL."""
+
+    return Artwork(
+        title=f"Artwork {index}",
+        description=f"Description {index}",
+        price_gbp="£10",
+        size="10 x 10 cm",
+        sold=False,
+        image_url=None,
+        materials_used=None,
+        source_url=product_url,
+    )
+
+
+def test_runner_processes_items_and_writes_jsonl(tmp_path) -> None:
+    listing_url = "https://example.com/listing/"
+    product_urls: List[str] = [
+        "https://example.com/product/one/",
+        "https://example.com/product/two/",
+    ]
+
+    call_log: list[tuple[str, str]] = []
+
+    async def fake_listing_iterator(listing: str, page, *, logger=None) -> AsyncIterator[str]:
+        assert listing == listing_url
+        for product_url in product_urls:
+            call_log.append(("index", product_url))
+            yield product_url
+
+    async def fake_fetch(product_url: str) -> str:
+        call_log.append(("fetch", product_url))
+        return f"<html>{product_url}</html>"
+
+    def fake_extractor(html: str, product_url: str) -> Artwork:
+        call_log.append(("extract", product_url))
+        slug_position = product_urls.index(product_url) + 1
+        return _build_artwork(product_url, slug_position)
+
+    class FakeDownloader:
+        def __init__(self) -> None:
+            self.downloaded: list[str] = []
+
+        def download_artwork_image(self, artwork: Artwork) -> Artwork:
+            self.downloaded.append(artwork.slug)
+            call_log.append(("download", artwork.slug))
+            return artwork
+
+    downloader = FakeDownloader()
+
+    def fake_normalizer(artwork: Artwork) -> dict[str, object]:
+        call_log.append(("normalize", artwork.slug))
+        return {
+            "title": artwork.title,
+            "slug": artwork.slug,
+            "source_url": str(artwork.source_url),
+            "scraped_at": artwork.scraped_at,
+            "price_gbp": artwork.price_gbp,
+        }
+
+    sleep_durations: list[float] = []
+
+    async def fake_sleep(duration: float) -> None:
+        sleep_durations.append(duration)
+
+    time_counter = {"value": 0.0}
+
+    def fake_time() -> float:
+        time_counter["value"] += 0.1
+        return time_counter["value"]
+
+    @asynccontextmanager
+    async def fake_page_factory():
+        yield object()
+
+    jsonl_path = tmp_path / "data" / "artworks.jsonl"
+
+    runner = ScraperRunner(
+        listing_url=listing_url,
+        fetch_html=fake_fetch,
+        extractor=fake_extractor,
+        normalizer=fake_normalizer,
+        downloader=downloader,
+        listing_iterator=fake_listing_iterator,
+        page_factory=fake_page_factory,
+        jsonl_path=jsonl_path,
+        rate_limit_seconds=0.5,
+        sleep_function=fake_sleep,
+        time_function=fake_time,
+        logger=logging.getLogger("scraper-runner-test"),
+    )
+
+    processed_artworks = asyncio.run(runner.crawl(max_items=2))
+
+    assert [artwork.slug for artwork in processed_artworks] == ["one", "two"]
+    assert sleep_durations, "Rate limiting hook should be invoked between requests"
+
+    expected_sequence = [
+        ("index", product_urls[0]),
+        ("fetch", product_urls[0]),
+        ("extract", product_urls[0]),
+        ("download", "one"),
+        ("normalize", "one"),
+        ("index", product_urls[1]),
+        ("fetch", product_urls[1]),
+        ("extract", product_urls[1]),
+        ("download", "two"),
+        ("normalize", "two"),
+    ]
+    assert call_log == expected_sequence
+
+    assert jsonl_path.exists()
+    json_lines = jsonl_path.read_text(encoding="utf-8").strip().splitlines()
+    assert len(json_lines) == 2
+    parsed_records = [json.loads(line) for line in json_lines]
+    assert {record["slug"] for record in parsed_records} == {"one", "two"}
+
+
+def test_runner_records_errors_and_continues(tmp_path, caplog) -> None:
+    listing_url = "https://example.com/listing/"
+    product_urls = [
+        "https://example.com/product/invalid/",
+        "https://example.com/product/valid/",
+    ]
+
+    async def fake_listing_iterator(listing: str, page, *, logger=None) -> AsyncIterator[str]:
+        for product_url in product_urls:
+            yield product_url
+
+    async def fake_fetch(product_url: str) -> str:
+        return "<html/>"
+
+    def failing_extractor(html: str, product_url: str) -> Artwork:
+        if product_url.endswith("invalid/"):
+            raise ValueError("missing title")
+        return _build_artwork(product_url, 1)
+
+    def fake_normalizer(artwork: Artwork) -> dict[str, object]:
+        return {
+            "title": artwork.title,
+            "slug": artwork.slug,
+            "source_url": str(artwork.source_url),
+            "scraped_at": artwork.scraped_at,
+        }
+
+    @asynccontextmanager
+    async def fake_page_factory():
+        yield object()
+
+    jsonl_path = tmp_path / "data" / "artworks.jsonl"
+
+    runner = ScraperRunner(
+        listing_url=listing_url,
+        fetch_html=fake_fetch,
+        extractor=failing_extractor,
+        normalizer=fake_normalizer,
+        listing_iterator=fake_listing_iterator,
+        page_factory=fake_page_factory,
+        jsonl_path=jsonl_path,
+        logger=logging.getLogger("scraper-runner-test"),
+    )
+
+    with caplog.at_level(logging.ERROR):
+        processed_artworks = asyncio.run(runner.crawl())
+
+    assert len(processed_artworks) == 1
+    assert runner.errors
+    first_error = runner.errors[0]
+    assert first_error.stage == "extract"
+    assert first_error.product_url.endswith("invalid/")
+
+    json_lines = jsonl_path.read_text(encoding="utf-8").strip().splitlines()
+    assert len(json_lines) == 1
+    remaining_record = json.loads(json_lines[0])
+    assert remaining_record["slug"] == "valid"
+

--- a/scrape_artfinder.py
+++ b/scrape_artfinder.py
@@ -110,12 +110,26 @@ def run_pipeline(
         "--listing-url",
         help="Listing URL to crawl for product links.",
     ),
+    jsonl_path: Optional[Path] = typer.Option(
+        None,
+        "--jsonl-path",
+        help="Location where JSONL records should be written.",
+    ),
+    rate_limit: float = typer.Option(
+        1.0,
+        "--rate-limit",
+        help="Minimum delay (in seconds) between detail page fetches.",
+    ),
 ) -> None:
     """Execute the end-to-end scraping pipeline for a limited number of items."""
 
-    runner = ScraperRunner(listing_url=listing_url)
+    runner = ScraperRunner(
+        listing_url=listing_url,
+        jsonl_path=jsonl_path,
+        rate_limit_seconds=rate_limit,
+    )
 
-    processed_artworks = asyncio.run(runner.crawl(max_items=limit))
+    processed_artworks = runner.run(max_items=limit)
     typer.echo(
         f"Processed {len(processed_artworks)} artwork(s); records appended to {runner.jsonl_path}"
     )


### PR DESCRIPTION
## Summary
- implement a ScraperRunner that coordinates pagination, extraction, normalization, image downloads, and JSONL persistence with error tracking
- add normalization helpers, documentation updates, and integration tests that validate the runner flow and JSONL output
- expose a `run` CLI command to execute the pipeline for a configurable number of items

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e0ed05f3d883228bba29bfe5b2caa4