### PR TITLE
Handle artwork description section markup

### DIFF
--- a/artfinder_scraper/scraping/readme.md
+++ b/artfinder_scraper/scraping/readme.md
@@ -6,13 +6,14 @@ command-line workflow to download and process Artfinder artwork pages.
 * `browsers.py` exposes `fetch_page_html`, a thin Playwright wrapper that
   requests a detail page with the required user agent and politeness delay.
 * `extractor.py` parses the rendered HTML into a dictionary of raw field
-  values that higher-level flows can normalize later on, including
-  consolidating size metadata from `product-attributes` spans while
-  stripping inert comment fragments from the collected text. It also
-  captures the "materials used" copy surfaced beneath the dedicated
-  `header-art` heading even when other `header-art` elements precede it,
-  flattening hyperlinks to plain text. The extractor now materializes an
-  `Artwork` pydantic model so that downstream components receive
+  values that higher-level flows can normalize later on. It now targets the
+  dedicated `#product-original h1 .title` span for the artwork name and
+  reads description plus materials copy from the structured
+  `.artwork-description` section while still falling back to legacy markup.
+  The extractor continues consolidating size metadata from
+  `product-attributes` spans, stripping inert comment fragments from the
+  collected text, and flattening hyperlinks to plain text. Parsed values are
+  materialized as an `Artwork` pydantic model so downstream components receive
   validated, typed data.
 * `models.py` defines the `Artwork` schema used across the scraping
   workflow, handling GBP price normalization, slug derivation from

--- a/artfinder_scraper/tests/fixtures/sounds_of_the_sea.html
+++ b/artfinder_scraper/tests/fixtures/sounds_of_the_sea.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Sounds of the Sea - Artfinder</title>
+    <meta property="og:image" content="https://cdn.example.com/images/sounds-of-the-sea.jpg" />
+  </head>
+  <body>
+    <main>
+      <div id="product-original">
+        <h1>
+          <span class="title">Sounds of the Sea</span>
+          <span class="medium">Oil on canvas</span>
+          <span class="artist">by Lizzie Butler</span>
+        </h1>
+      </div>
+      <section class="artwork-description">
+        <h5>About the artwork</h5>
+        <div class="copy">
+          <p>A shimmering horizon captures the rhythm of the shoreline.</p>
+          <p>Oil, pastel and charcoal layered on primed canvas.</p>
+        </div>
+      </section>
+      <section class="specifications">
+        <div class="product-attributes">
+          <span>Size</span>
+          <span>: 60 x 60 x 2cm</span>
+          <span>(unframed)</span>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/artfinder_scraper/tests/test_extractor.py
+++ b/artfinder_scraper/tests/test_extractor.py
@@ -14,7 +14,11 @@ FIXTURES_DIR = Path(__file__).parent / "fixtures"
 
 @pytest.mark.parametrize(
     "fixture_name",
-    ["windswept_walk.html", "soft_light_sold.html"],
+    [
+        "windswept_walk.html",
+        "soft_light_sold.html",
+        "sounds_of_the_sea.html",
+    ],
 )
 def test_fixtures_exist(fixture_name: str) -> None:
     """Ensure fixtures referenced in the tests are present on disk."""
@@ -86,6 +90,24 @@ def test_extract_artwork_fields_handles_sold_item_with_missing_depth() -> None:
     assert (
         str(artwork.source_url)
         == "https://www.artfinder.com/product/soft-light-kew-gardens-an-atmospheric-oil-painting/"
+    )
+
+
+def test_extract_artwork_fields_handles_artwork_description_section() -> None:
+    html = _load_fixture("sounds_of_the_sea.html")
+
+    artwork = extract_artwork_fields(
+        html, "https://www.artfinder.com/product/sounds-of-the-sea-a4bae/"
+    )
+
+    assert artwork.title == "Sounds of the Sea"
+    assert (
+        artwork.description
+        == "A shimmering horizon captures the rhythm of the shoreline."
+    )
+    assert (
+        artwork.materials_used
+        == "Oil, pastel and charcoal layered on primed canvas."
     )
 
 


### PR DESCRIPTION
## Summary
- ensure titles are captured from the dedicated `#product-original h1 .title` span when available
- parse description and materials copy from the `.artwork-description` section while retaining legacy fallbacks
- add fixture and regression test covering the "Sounds of the Sea" layout and document the extractor update

## Testing
- pytest artfinder_scraper/tests/test_extractor.py

------
https://chatgpt.com/codex/tasks/task_e_68e0f5e1f1288322adb580d3b6d2b4d0