### PR TITLE
Update tests to use fictional Artfinder fixtures

### DIFF
--- a/artfinder_scraper/README.md
+++ b/artfinder_scraper/README.md
@@ -15,3 +15,7 @@ python scrape_artfinder.py fetch-item https://www.artfinder.com/product/echoes-o
 ```
 
 Pass `--out path/to/file.html` to store the rendered HTML instead of printing it to the terminal. Use `--download-image` to save the hero image to `out/images/` while reporting the stored path in the console output.
+
+## Test fixtures
+
+Tests exercise the parsing helpers with anonymized HTML fixtures. The fixtures reference fictional artist names, artwork titles, descriptions, and URLs to ensure the suite avoids real-world listings while still covering the expected extraction logic.

--- a/artfinder_scraper/tests/fixtures/soft_light_sold.html
+++ b/artfinder_scraper/tests/fixtures/soft_light_sold.html
@@ -8,11 +8,11 @@
     <main>
       <div id="product-original">
         <h1>
-          <span class="title">Soft Light</span>
+          <span class="title">Lantern Glow</span>
           <span class="subtitle">
             <a href="/medium/original-painting">
               Original painting<br />
-              by Lizzie Butler
+              by Example Artist
             </a>
           </span>
         </h1>

--- a/artfinder_scraper/tests/fixtures/sounds_of_the_sea.html
+++ b/artfinder_scraper/tests/fixtures/sounds_of_the_sea.html
@@ -13,7 +13,7 @@
           <span class="subtitle">
             <a href="/medium/oil-on-canvas">
               Oil on canvas<br />
-              by Lizzie Butler
+              by Example Artist
             </a>
           </span>
         </h1>

--- a/artfinder_scraper/tests/fixtures/windswept_walk.html
+++ b/artfinder_scraper/tests/fixtures/windswept_walk.html
@@ -9,11 +9,11 @@
     <main>
       <div id="product-original">
         <h1>
-          <span class="title">A Windswept Walk</span>
+          <span class="title">Echoes of Dawn</span>
           <span class="subtitle">
             <a href="/medium/oil-painting">
               Oil painting<br />
-              by Lizzie Butler
+              by Example Artist
             </a>
           </span>
         </h1>


### PR DESCRIPTION
## Summary
- replace remaining real artwork titles and artist names in HTML fixtures with fictional metadata so extractor expectations align with anonymized data
- document in the package README that tests rely on fictionalized fixtures to validate parsing logic

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e0fe0a2b388322a344a8a06314eb18