### PR TITLE
Add skip-images flag to main scraper run

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Key options:
 * `--jsonl-path` – store the JSONL output somewhere other than the default project location.
 * `--rate-limit` – control the minimum delay between detail page fetches.
 * `--dry-run` – execute the crawl without downloading images or writing JSONL/Excel output.
+* `--skip-images` – persist JSONL/Excel data while skipping image downloads.
 
 The command prints a one-line summary when complete and lists any recoverable errors that were skipped along the way so you can iterate on extraction fidelity.
 

--- a/artfinder_scraper/scraping/readme.md
+++ b/artfinder_scraper/scraping/readme.md
@@ -68,6 +68,9 @@ can feed them directly into the detail-page workflow.
 Run `python scrape_artfinder.py run` to execute the full pipeline. The command
 now accepts `--dry-run` to exercise listing pagination, parsing, and
 normalization without downloading images or mutating the JSONL/Excel outputs.
+Use `--skip-images` to keep writing JSONL/Excel data while bypassing the
+downloader, which is helpful when the spreadsheet is the only required output
+or when bandwidth is limited.
 
 Resume a previously interrupted crawl with `python scrape_artfinder.py resume`.
 It reads the JSONL archive to collect processed slugs, skips those URLs, and

--- a/artfinder_scraper/scraping/runner.py
+++ b/artfinder_scraper/scraping/runner.py
@@ -61,6 +61,7 @@ class ScraperRunner:
         spreadsheet_writer: Callable[[Artwork, Path], bool] | None = None,
         skip_slugs: Iterable[str] | None = None,
         persist_outputs: bool = True,
+        download_images: bool = True,
     ) -> None:
         self.listing_url = listing_url
         self.fetch_html = fetch_html
@@ -80,6 +81,7 @@ class ScraperRunner:
         self.spreadsheet_writer = spreadsheet_writer or append_artwork_to_spreadsheet
         self.skip_slugs: set[str] = {slug.strip() for slug in skip_slugs or [] if slug.strip()}
         self.persist_outputs = persist_outputs
+        self.download_images = download_images
         self.errors: list[RunnerError] = []
 
     async def crawl(self, *, max_items: int | None = None) -> list[Artwork]:
@@ -119,7 +121,7 @@ class ScraperRunner:
                     self._record_error(product_url, "extract", error)
                     continue
 
-                if self.persist_outputs:
+                if self.persist_outputs and self.download_images:
                     try:
                         artwork = self._download_artwork_image(artwork)
                     except ImageDownloadError as error:

--- a/artfinder_scraper/tests/test_runner.py
+++ b/artfinder_scraper/tests/test_runner.py
@@ -144,6 +144,106 @@ def test_runner_processes_items_and_writes_jsonl(tmp_path) -> None:
     assert spreadsheet_calls == [spreadsheet_path, spreadsheet_path]
 
 
+def test_runner_can_skip_image_downloads(tmp_path) -> None:
+    listing_url = "https://example.com/listing/"
+    product_urls: List[str] = [
+        "https://example.com/product/one/",
+        "https://example.com/product/two/",
+    ]
+
+    call_log: list[tuple[str, str]] = []
+
+    async def fake_listing_iterator(listing: str, page, *, logger=None) -> AsyncIterator[str]:
+        assert listing == listing_url
+        for product_url in product_urls:
+            call_log.append(("index", product_url))
+            yield product_url
+
+    async def fake_fetch(product_url: str) -> str:
+        call_log.append(("fetch", product_url))
+        return f"<html>{product_url}</html>"
+
+    def fake_extractor(html: str, product_url: str) -> Artwork:
+        call_log.append(("extract", product_url))
+        slug_position = product_urls.index(product_url) + 1
+        return _build_artwork(product_url, slug_position)
+
+    class FakeDownloader:
+        def __init__(self) -> None:
+            self.downloaded: list[str] = []
+
+        def download_artwork_image(self, artwork: Artwork) -> Artwork:
+            self.downloaded.append(artwork.slug)
+            call_log.append(("download", artwork.slug))
+            return artwork
+
+    downloader = FakeDownloader()
+
+    def fake_normalizer(artwork: Artwork) -> dict[str, object]:
+        call_log.append(("normalize", artwork.slug))
+        return {
+            "title": artwork.title,
+            "slug": artwork.slug,
+            "source_url": str(artwork.source_url),
+            "scraped_at": artwork.scraped_at,
+            "price_gbp": artwork.price_gbp,
+        }
+
+    def fake_spreadsheet_writer(artwork: Artwork, path) -> bool:
+        call_log.append(("spreadsheet", artwork.slug))
+        spreadsheet_calls.append(path)
+        return True
+
+    @asynccontextmanager
+    async def fake_page_factory():
+        yield object()
+
+    jsonl_path = tmp_path / "data" / "artworks.jsonl"
+    spreadsheet_path = tmp_path / "data" / "artworks.xlsx"
+    spreadsheet_calls: list[Path] = []
+
+    runner = ScraperRunner(
+        listing_url=listing_url,
+        fetch_html=fake_fetch,
+        extractor=fake_extractor,
+        normalizer=fake_normalizer,
+        downloader=downloader,
+        listing_iterator=fake_listing_iterator,
+        page_factory=fake_page_factory,
+        jsonl_path=jsonl_path,
+        spreadsheet_path=spreadsheet_path,
+        logger=logging.getLogger("scraper-runner-test"),
+        spreadsheet_writer=fake_spreadsheet_writer,
+        download_images=False,
+    )
+
+    processed_artworks = asyncio.run(runner.crawl(max_items=2))
+
+    assert [artwork.slug for artwork in processed_artworks] == ["one", "two"]
+    assert downloader.downloaded == []
+
+    expected_sequence = [
+        ("index", product_urls[0]),
+        ("fetch", product_urls[0]),
+        ("extract", product_urls[0]),
+        ("normalize", "one"),
+        ("spreadsheet", "one"),
+        ("index", product_urls[1]),
+        ("fetch", product_urls[1]),
+        ("extract", product_urls[1]),
+        ("normalize", "two"),
+        ("spreadsheet", "two"),
+    ]
+    assert call_log == expected_sequence
+
+    assert jsonl_path.exists()
+    json_lines = jsonl_path.read_text(encoding="utf-8").strip().splitlines()
+    assert len(json_lines) == 2
+    parsed_records = [json.loads(line) for line in json_lines]
+    assert {record["slug"] for record in parsed_records} == {"one", "two"}
+    assert spreadsheet_calls == [spreadsheet_path, spreadsheet_path]
+
+
 def test_runner_records_errors_and_continues(tmp_path, caplog) -> None:
     listing_url = "https://example.com/listing/"
     product_urls = [

--- a/scrape_artfinder.py
+++ b/scrape_artfinder.py
@@ -107,6 +107,7 @@ def _create_runner(
     rate_limit: float,
     dry_run: bool,
     skip_slugs: Iterable[str] | None = None,
+    download_images: bool = True,
 ) -> ScraperRunner:
     return ScraperRunner(
         listing_url=listing_url,
@@ -114,6 +115,7 @@ def _create_runner(
         rate_limit_seconds=rate_limit,
         skip_slugs=skip_slugs,
         persist_outputs=not dry_run,
+        download_images=download_images,
     )
 
 
@@ -197,6 +199,12 @@ def run_pipeline(
         help="Process items without downloading images or writing JSONL/spreadsheet files.",
         is_flag=True,
     ),
+    skip_images: bool = typer.Option(
+        False,
+        "--skip-images",
+        help="Skip downloading artwork images while still writing JSONL/spreadsheet outputs.",
+        is_flag=True,
+    ),
 ) -> None:
     """Execute the end-to-end scraping pipeline for a limited number of items."""
 
@@ -206,6 +214,7 @@ def run_pipeline(
         rate_limit=rate_limit,
         dry_run=dry_run,
         skip_slugs=None,
+        download_images=not skip_images,
     )
     _execute_pipeline(runner, limit)
 


### PR DESCRIPTION
## Summary
- add a `--skip-images` option to the `run` command so operators can persist data without downloading artwork media
- extend `ScraperRunner` with configurable image downloading and describe the flag in project documentation
- cover the new flag with orchestration tests to ensure JSONL and spreadsheet updates still succeed

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e1447b0c308322adf0f72d2ebfff02